### PR TITLE
Add image attribution, final steps

### DIFF
--- a/packages/ui/src/app/app.tsx
+++ b/packages/ui/src/app/app.tsx
@@ -135,7 +135,28 @@ class App extends Component<
               width: '100%',
               height: '90vh',
             }}
-          ></div>
+          >
+            {/* image attribution */}
+            <div
+              style={{
+                position: 'absolute',
+                bottom: '10px',
+                left: '10px',
+                fontSize: '8px',
+                color: '#888',
+              }}
+            >
+              <a
+                style={{
+                  color: '#555',
+                  zIndex: 1000000,
+                }}
+                href="https://www.freepik.com/vectors/digital-devices"
+              >
+                Digital devices vector created by rawpixel.com - www.freepik.com
+              </a>
+            </div>
+          </div>
         </div>
 
         {/* fixed container */}

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import Page from './app/app';
 
+// Highlights an object/area in the JSON editor based on the key, and optionally the next key.
 const editorHighlightAreaSelectors = (
   startProperty: string,
   endProperty?: string
@@ -108,7 +109,17 @@ const steps: StepType[] = [
   {
     // step 16
     selector: 'html',
-    content: `Thanks for taking this quick tour of OpenFeature!`,
+    content: `That's it for our tour, but one more thing: as previously mentioned, one of the core benefits of OpenFeature is a consistent API across feature flag management systems...`,
+  },
+  {
+    // step 17
+    selector: 'html',
+    content: `You can start the same tour with a different demo "provider", and connect OpenFeature to the SaaS Vendor of your choice, or you can create a custom provider of your own! Check out this project's README for more info.`,
+  },
+  {
+    // step 18
+    selector: 'html',
+    content: `Thanks for taking this quick tour of OpenFeature.`,
   },
 ];
 


### PR DESCRIPTION
Adding attribution for free image (required, see bottom left of screenshot) and a couple final steps mentioning other demo providers.

![image](https://user-images.githubusercontent.com/25272906/168071740-a5001ca2-00e7-42f1-ae3f-cc7aec585481.png)
