### PR TITLE
Use symbol for global OpenFeature key

### DIFF
--- a/packages/openfeature-js/src/lib/global.ts
+++ b/packages/openfeature-js/src/lib/global.ts
@@ -1,14 +1,6 @@
 import { OpenFeatureAPI } from './api';
 
-/**
- * A string is used here instead of a symbols only for demo purposes. In this
- * situation, it wasn't possible to use a symbol because provider registration
- * code was using a relative import while the rest of the code was doing an
- * aliased import. This meant the require cache couldn't be used and multiple symbols
- * were registered.
- */
-// export const GLOBAL_OPENFEATURE_API_KEY = Symbol('openfeature.js.api');
-export const GLOBAL_OPENFEATURE_API_KEY = 'openfeature.js.api';
+export const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('openfeature.js.api');
 
 const _global = global as OpenFeatureGlobal;
 


### PR DESCRIPTION
Using `Symbol.for` will also look up the key in the global registry so whether or not being imported by relative, absolute, or duplicate modules, the symbol will be identical.

**Note**: Opening as a draft to validate later.