### PR TITLE
fix: mounted volumes use relative paths

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - jaeger
       - fib-service
     volumes:
-      - ${PWD}/config/flagd/flags.json:/opt/playground/config/flagd/flags.json
+      - ./config/flagd/flags.json:/opt/playground/config/flagd/flags.json
     environment:
      - FLAGD_HOST=flagd
      - OTEL_EXPORTER_JAEGER_AGENT_HOST=jaeger
@@ -61,14 +61,14 @@ services:
       - --uri
       - /etc/flagd/flags.json
     volumes:
-      - ${PWD}/config/flagd/flags.json:/etc/flagd/flags.json
+      - ./config/flagd/flags.json:/etc/flagd/flags.json
     expose:
       - "8013"
 
   go-feature-flag:
     image: thomaspoignant/go-feature-flag-relay-proxy:v0.3.0
     volumes:
-      - ${PWD}/config/go-feature-flag:/goff/
+      - ./config/go-feature-flag:/goff/
     expose:
      - 1031
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Removed the PWD command from the docker compose file so that it runs on a Windows environment.

Fixes #116 

### How to test

Manually ran on both Windows and Linux.

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>

