### PR TITLE
fix(docker-compose): update sync provider flagd argument

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
     command:
       - start
       - --uri
-      - /etc/flagd/flags.json
+      - file://etc/flagd/flags.json
     volumes:
       - ./config/flagd/flags.json:/etc/flagd/flags.json
     expose:


### PR DESCRIPTION
Addresses changes introduced by flagd 0.2.7 described [here](https://github.com/open-feature/flagd/pull/222).

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>