### PR TITLE
ci: run ci on renovate branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 on:
   push:
-    branches: ["main"]
+    branches:
+      - 'main'
+      - 'renovate/**'
   pull_request:
-    branches: ["main"]
+    branches:
+      - 'main'
 
 jobs:
   main:


### PR DESCRIPTION
## This PR

- updates the ci to run on renovate branches

### Notes

This should address the pending automerge branches listed [here](https://github.com/open-feature/playground/issues/132).

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>