### PR TITLE
feat: add support for a configurable flagd host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,7 @@ FLAGSMITH_ENV_KEY_WEB=
 
 # Harness SDK Key
 HARNESS_KEY_WEB=
+
+# The domain name or IP address of flagd
+# @default localhost
+FLAGD_HOST_WEB=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       - LD_KEY_WEB
       - FLAGSMITH_ENV_KEY_WEB
       - CLOUDBEES_APP_KEY_WEB
+      - FLAGD_HOST_WEB
 
   fib-service:
     image: ghcr.io/open-feature/playground-fib-service:v0.6.3 # x-release-please-version

--- a/packages/provider/src/lib/provider.service.ts
+++ b/packages/provider/src/lib/provider.service.ts
@@ -12,7 +12,17 @@ import Flagsmith from 'flagsmith-nodejs';
 import { Client } from '@harnessio/ff-nodejs-server-sdk';
 import { OpenFeatureHarnessProvider } from '@openfeature/js-harness-provider';
 import { OpenFeatureLogger } from '@openfeature/extra';
-import { AvailableProvider, CB_PROVIDER_ID, ENV_PROVIDER_ID, FLAGD_PROVIDER_ID, FLAGSMITH_PROVIDER_ID, GO_PROVIDER_ID, HARNESS_PROVIDER_ID, ProviderId, SPLIT_PROVIDER_ID } from '@openfeature/utils';
+import {
+  AvailableProvider,
+  CB_PROVIDER_ID,
+  ENV_PROVIDER_ID,
+  FLAGD_PROVIDER_ID,
+  FLAGSMITH_PROVIDER_ID,
+  GO_PROVIDER_ID,
+  HARNESS_PROVIDER_ID,
+  ProviderId,
+  SPLIT_PROVIDER_ID,
+} from '@openfeature/utils';
 
 type ProviderMap = Record<
   ProviderId,
@@ -21,6 +31,7 @@ type ProviderMap = Record<
     available?: () => boolean;
     factory: () => Promise<Provider> | Provider;
     webCredential?: string;
+    host?: string;
   }
 >;
 
@@ -30,7 +41,10 @@ export class ProviderService {
   private _currentProvider: ProviderId;
   private providerMap: ProviderMap = {
     [ENV_PROVIDER_ID]: { factory: () => new OpenFeatureEnvProvider() },
-    [FLAGD_PROVIDER_ID]: { factory: () => new FlagdProvider() },
+    [FLAGD_PROVIDER_ID]: {
+      factory: () => new FlagdProvider(),
+      host: process.env.FLAGD_HOST_WEB ?? 'localhost',
+    },
     launchdarkly: {
       factory: () => {
         const sdkKey = process.env.LD_KEY;
@@ -83,7 +97,7 @@ export class ProviderService {
         new GoFeatureFlagProvider({
           endpoint: process.env.GO_FEATURE_FLAG_URL as string,
         }),
-        available: () => !!process.env.GO_FEATURE_FLAG_URL,
+      available: () => !!process.env.GO_FEATURE_FLAG_URL,
     },
     [FLAGSMITH_PROVIDER_ID]: {
       factory: () => {
@@ -164,8 +178,9 @@ export class ProviderService {
       .map((p) => {
         return {
           id: p[0] as ProviderId,
-          webCredential: p[1].webCredential
-        }
+          webCredential: p[1].webCredential,
+          host: p[1].host,
+        };
       });
   }
 }

--- a/packages/ui/src/app/app.tsx
+++ b/packages/ui/src/app/app.tsx
@@ -1,7 +1,16 @@
 import { Box, Modal, SelectChangeEvent } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { FlagdWebProvider } from '@openfeature/flagd-web-provider';
-import { AvailableProvider, CB_PROVIDER_ID, FLAGD_PROVIDER_ID, FLAGSMITH_PROVIDER_ID, HARNESS_PROVIDER_ID, LD_PROVIDER_ID, ProviderId, SPLIT_PROVIDER_ID } from '@openfeature/utils';
+import {
+  AvailableProvider,
+  CB_PROVIDER_ID,
+  FLAGD_PROVIDER_ID,
+  FLAGSMITH_PROVIDER_ID,
+  HARNESS_PROVIDER_ID,
+  LD_PROVIDER_ID,
+  ProviderId,
+  SPLIT_PROVIDER_ID,
+} from '@openfeature/utils';
 import { CloudbeesWebProvider } from '@openfeature/web-cloudbees-provider';
 import { FlagsmithProvider } from '@openfeature/web-flagsmith-provider';
 import { HarnessWebProvider } from '@openfeature/web-harness-provider';
@@ -60,35 +69,45 @@ class App extends Component<
   private providerMap: ProviderMap = {
     [FLAGD_PROVIDER_ID]: {
       factory: () => {
-        return new FlagdWebProvider({ host: 'localhost', port: 8013, tls: false }, console);
-      }
+        return new FlagdWebProvider(
+          {
+            host: this.state.availableProviders.find((p) => p.id === FLAGD_PROVIDER_ID)?.host ?? 'localhost',
+            port: 8013,
+            tls: false,
+          },
+          console
+        );
+      },
     },
     [HARNESS_PROVIDER_ID]: {
       factory: () => {
         return new HarnessWebProvider(this.getProviderCredential(HARNESS_PROVIDER_ID), console);
-      }
+      },
     },
     [CB_PROVIDER_ID]: {
       factory: () => {
         console.log(this.getProviderCredential(CB_PROVIDER_ID));
         return new CloudbeesWebProvider({ key: this.getProviderCredential(CB_PROVIDER_ID), logger: console });
-      }
+      },
     },
     [FLAGSMITH_PROVIDER_ID]: {
       factory: () => {
-        return new FlagsmithProvider({ logger: console, environmentID: this.getProviderCredential(FLAGSMITH_PROVIDER_ID) });
-      }
+        return new FlagsmithProvider({
+          logger: console,
+          environmentID: this.getProviderCredential(FLAGSMITH_PROVIDER_ID),
+        });
+      },
     },
     [LD_PROVIDER_ID]: {
       factory: () => {
         return new LaunchDarklyProvider({ logger: console, clientSideId: this.getProviderCredential(LD_PROVIDER_ID) });
-      }
+      },
     },
     [SPLIT_PROVIDER_ID]: {
       factory: () => {
         return new SplitWebProvider(this.getProviderCredential(SPLIT_PROVIDER_ID));
-      }
-    }
+      },
+    },
   };
 
   constructor(props: TourProps) {
@@ -193,7 +212,9 @@ class App extends Component<
           <div className="json-editor">
             <JsonEditor
               errorMessage={
-                this.state.jsonErrors ? `${this.state.jsonErrors?.[0].schemaPath} ${this.state.jsonErrors?.[0].message}` : undefined
+                this.state.jsonErrors
+                  ? `${this.state.jsonErrors?.[0].schemaPath} ${this.state.jsonErrors?.[0].message}`
+                  : undefined
               }
               hidden={!this.state.editorOn}
               callBack={this.onJsonUpdate.bind(this)}
@@ -258,10 +279,10 @@ class App extends Component<
   }
 
   private async evaluateUiFlags() {
-    const [ newMessage, hex ] = [
+    const [newMessage, hex] = [
       // evaluate the "new-welcome-message" flag
       this.client.getBooleanValue('new-welcome-message', false),
-      
+
       // evaluate the "hex-color" flag
       this.client.getStringValue('hex-color', DEFAULT_HEX, {
         hooks: [
@@ -281,7 +302,7 @@ class App extends Component<
               }
             },
           },
-        ]
+        ],
       }),
     ];
     this.setState({ welcomeMessage: newMessage, hexColor: `#${hex}` });
@@ -410,10 +431,7 @@ class App extends Component<
 
   private async getConfig() {
     try {
-      const promises: [
-        Promise<{ provider: string }>,
-        Promise<unknown>
-      ] = [
+      const promises: [Promise<{ provider: string }>, Promise<unknown>] = [
         this.getData<{ provider: string }>('/providers/current'),
         this.getData<unknown>('/utils/json'),
       ];
@@ -463,12 +481,12 @@ class App extends Component<
     throw Error(`HTTP status error: ${response.statusText}`);
   }
 
-  private getProviderCredential(prividerId: ProviderId): string {
-    const credential = this.state.availableProviders.find(p => p.id === prividerId)?.webCredential;
+  private getProviderCredential(providerId: ProviderId): string {
+    const credential = this.state.availableProviders.find((p) => p.id === providerId)?.webCredential;
     if (credential) {
       return credential;
     }
-    throw new Error(`Credential not available for ${prividerId}`);
+    throw new Error(`Credential not available for ${providerId}`);
   }
 }
 

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -20,4 +20,5 @@ export type ProviderId =
 export interface AvailableProvider {
     id: ProviderId,
     webCredential?: string,
+    host?: string,
 }


### PR DESCRIPTION
## This PR

- adds support for a configurable flagd

### Notes

This can be used when the playground is deployed to Kubernetes.

### How to test

Set the `FLAGD_HOST_WEB` environment variable before starting docker compose. Inspect the provider call to see the host value.

