### PR TITLE
chore: disable k8s upgrade

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,7 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "extra-files": [
-        "docker-compose.yaml",
-        "config/k8s/end-to-end.yaml"
+        "docker-compose.yaml"
       ]
     }
   },


### PR DESCRIPTION
## This PR

- Temporarily disable automatic version upgrades in k8s

### Follow-up Tasks

- Update k8s tutorial to support client-side feature flags
- Revert this change
- Manually update [the image version](https://github.com/open-feature/playground/blob/main/config/k8s/end-to-end.yaml#L78) to the latest


