### PR TITLE
feat: add additional flagd web config options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,11 @@ HARNESS_KEY_WEB=
 # The domain name or IP address of flagd
 # @default localhost
 FLAGD_HOST_WEB=
+
+# The port at which the flagd gRPC service is exposed
+# @default 8013
+FLAGD_PORT_WEB=
+
+# Determines if TLS (https) should be used
+# @default false
+FLAGD_TLS_WEB=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
       - FLAGSMITH_ENV_KEY_WEB
       - CLOUDBEES_APP_KEY_WEB
       - FLAGD_HOST_WEB
+      - FLAGD_PORT_WEB
+      - FLAGD_TLS_WEB
 
   fib-service:
     image: ghcr.io/open-feature/playground-fib-service:v0.7.1 # x-release-please-version

--- a/packages/provider/src/lib/provider.service.ts
+++ b/packages/provider/src/lib/provider.service.ts
@@ -30,9 +30,7 @@ type ProviderMap = Record<
     provider?: Provider;
     available?: () => boolean;
     factory: () => Promise<Provider> | Provider;
-    webCredential?: string;
-    host?: string;
-  }
+  } & Omit<AvailableProvider, 'id'>
 >;
 
 @Injectable()
@@ -44,6 +42,9 @@ export class ProviderService {
     [FLAGD_PROVIDER_ID]: {
       factory: () => new FlagdProvider(),
       host: process.env.FLAGD_HOST_WEB ?? 'localhost',
+      // double NOT bitwise operator used to convert env to number or default
+      port: ~~(process.env.FLAGD_PORT_WEB ?? 8013),
+      tls: process.env.FLAGD_TLS_WEB === 'true',
     },
     launchdarkly: {
       factory: () => {
@@ -180,6 +181,8 @@ export class ProviderService {
           id: p[0] as ProviderId,
           webCredential: p[1].webCredential,
           host: p[1].host,
+          port: p[1].port,
+          tls: p[1].tls,
         };
       });
   }

--- a/packages/ui/src/app/app.tsx
+++ b/packages/ui/src/app/app.tsx
@@ -69,11 +69,12 @@ class App extends Component<
   private providerMap: ProviderMap = {
     [FLAGD_PROVIDER_ID]: {
       factory: () => {
+        const flagdConfig = this.state.availableProviders.find((p) => p.id === FLAGD_PROVIDER_ID);
         return new FlagdWebProvider(
           {
-            host: this.state.availableProviders.find((p) => p.id === FLAGD_PROVIDER_ID)?.host ?? 'localhost',
-            port: 8013,
-            tls: false,
+            host: flagdConfig?.host ?? 'localhost',
+            port: flagdConfig?.port ?? 8013,
+            tls: flagdConfig?.tls ?? false,
           },
           console
         );

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -18,7 +18,9 @@ export type ProviderId =
   | typeof HARNESS_PROVIDER_ID;
 
 export interface AvailableProvider {
-    id: ProviderId,
-    webCredential?: string,
-    host?: string,
+  id: ProviderId;
+  webCredential?: string;
+  host?: string;
+  tls?: boolean;
+  port?: number;
 }


### PR DESCRIPTION
## This PR

- add additional flagd web config options

### Notes

It's now possible to define `FLAGD_PORT_WEB` and `FLAGD_TLS_WEB` as environment variables in the demo app.

