### PR TITLE
fix: update jaeger config to use otlp

### DIFF
--- a/config/otel/collector.yaml
+++ b/config/otel/collector.yaml
@@ -5,8 +5,8 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-  jaeger:
-    endpoint: jaeger:14250
+  otlp/jaeger:
+    endpoint: jaeger:4317
     tls:
       insecure: true
 processors:
@@ -16,7 +16,7 @@ service:
     traces:
       receivers: [ otlp ]
       processors: [ batch ]
-      exporters: [ jaeger ]
+      exporters: [ otlp/jaeger ]
     metrics:
       receivers: [ otlp ]
       processors: [ batch ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,14 +73,15 @@ services:
       - CLOUDBEES_APP_KEY
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:1.49.0
     expose:
       - '6832/udp'
+      - '4317'
     ports:
       - '16686:16686'
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.85.0
     restart: always
     command: [ "--config=/etc/otel-collector-config.yaml" ]
     volumes:
@@ -96,7 +97,7 @@ services:
 
   prometheus:
     container_name: prometheus
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.47.0
     restart: always
     volumes:
       - ./config/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml


### PR DESCRIPTION
## This PR

- updated OTel exporter to use OTLP

### Related Issues

Fixes #245 

### Notes

The OTel collector removed support for the Jaeger exporters. The standard OTLP exporter should be used instead.


