### PR TITLE
feat: client-side flags in e2e k8s demo

### DIFF
--- a/config/k8s/end-to-end.yaml
+++ b/config/k8s/end-to-end.yaml
@@ -127,6 +127,7 @@ spec:
       nodePort: 30000
 ---
 # Service to expose flagd for client-side evaluations
+# Note that in production, it's recommended to run a dedicated flagd deployment to serve client-side evaluations.
 apiVersion: v1
 kind: Service
 metadata:

--- a/config/k8s/end-to-end.yaml
+++ b/config/k8s/end-to-end.yaml
@@ -1,4 +1,4 @@
-# A basic flag custom resource
+# Flags for our UI
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlag
 metadata:
@@ -31,7 +31,7 @@ spec:
             - yellow
             - null
 ---
-# A basic flag custom resource
+# Flags for our backend application
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlag
 metadata:

--- a/config/k8s/end-to-end.yaml
+++ b/config/k8s/end-to-end.yaml
@@ -2,7 +2,7 @@
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlag
 metadata:
-  name: end-to-end
+  name: ui-flags
   labels:
     app: open-feature-demo
 spec:
@@ -30,6 +30,17 @@ spec:
                 - email
             - yellow
             - null
+---
+# A basic flag custom resource
+apiVersion: core.openfeature.dev/v1beta1
+kind: FeatureFlag
+metadata:
+  name: app-flags
+  labels:
+    app: open-feature-demo
+spec:
+  flagSpec:
+    flags:
       fib-algo:
         variants:
           recursive: recursive
@@ -53,20 +64,22 @@ spec:
           'off': false
         defaultVariant: 'off'
 ---
-# Feature flag source custom resource, configuring flagd to source flags from FeatureFlag crd
+# Feature flag source custom resource, configuring flagd to source flags from FeatureFlag CRDs
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlagSource
 metadata:
-  name: end-to-end
+  name: flag-sources
   labels:
     app: open-feature-demo
 spec:
   sources:
-    - source: end-to-end
+    - source: app-flags
+      provider: kubernetes
+    - source: ui-flags
       provider: kubernetes
 
 ---
-# Deployment of a demo-app using our custom resource
+# Deployment of a demo-app using our custom resources
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +97,7 @@ spec:
         app: open-feature-demo
       annotations:
         openfeature.dev/enabled: "true"
-        openfeature.dev/featureflagsource: "end-to-end"
+        openfeature.dev/featureflagsource: "flag-sources"
     spec:
       containers:
         - name: open-feature-demo
@@ -93,13 +106,15 @@ spec:
             - flagd
           ports:
             - containerPort: 30000
-
+          env:
+            - name: FLAGD_PORT_WEB
+              value: "30002"
 ---
-# Service exposed using NodePort
+# Service to expose our application
 apiVersion: v1
 kind: Service
 metadata:
-  name: open-feature-demo-service
+  name: open-feature-demo-app-service
   labels:
     app: open-feature-demo
 spec:
@@ -107,7 +122,22 @@ spec:
   selector:
     app: open-feature-demo
   ports:
-    # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
     - port: 30000
       targetPort: 30000
       nodePort: 30000
+---
+# Service to expose flagd for client-side evaluations
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-feature-demo-ui-service
+  labels:
+    app: open-feature-demo
+spec:
+  type: NodePort
+  selector:
+    app: open-feature-demo
+  ports:
+    - port: 30002
+      targetPort: 8013
+      nodePort: 30002


### PR DESCRIPTION
Adds client-side flag support in `end-to-end.yaml`. I will update the OFO tutorial in openfeature.dev to use this next.