### PR TITLE
fix: make goff url for web configurable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - OTEL_EXPORTER_JAEGER_AGENT_HOST=jaeger
       - OTEL_EXPORTER_JAEGER_AGENT_PORT=6832
       - GO_FEATURE_FLAG_URL=http://go-feature-flag:1031
+      - GO_FEATURE_FLAG_WEB_URL=http://localhost:1031
       - FIB_SERVICE_URL=http://fib-service:30001
       - FIB_SERVICE_USER
       - FIB_SERVICE_PASS

--- a/packages/provider/src/lib/provider.service.ts
+++ b/packages/provider/src/lib/provider.service.ts
@@ -113,14 +113,14 @@ export class ProviderService {
         new GoFeatureFlagProvider({
           endpoint: process.env.GO_FEATURE_FLAG_URL as string,
         }),
-      available: () => !!process.env.GO_FEATURE_FLAG_URL,
+      available: () => !!process.env.GO_FEATURE_FLAG_WEB_URL,
     },
     [GO_OFREP_PROVIDER_ID]: {
       factory: () => {
         return new OFREPProvider({ baseUrl: process.env.GO_FEATURE_FLAG_URL as string });
       },
       available: () => !!process.env.GO_FEATURE_FLAG_URL,
-      url: process.env.GO_FEATURE_FLAG_URL as string
+      url: process.env.GO_FEATURE_FLAG_WEB_URL as string
     },
     [FLAGSMITH_PROVIDER_ID]: {
       factory: () => {
@@ -205,6 +205,7 @@ export class ProviderService {
           host: p[1].host,
           port: p[1].port,
           tls: p[1].tls,
+          url: p[1].url
         };
       });
   }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Makes Go Feature Flag URL configurable for the web
- Sends configured URL for provider initialization
