### PR TITLE
feat: additional ofo tutorial resources

### DIFF
--- a/config/k8s/client-side-evaluation.yaml
+++ b/config/k8s/client-side-evaluation.yaml
@@ -49,7 +49,7 @@ kind: Flagd
 metadata:
   name: flagd-ui
 spec:
-  replicas: 2
+  replicas: 1
   serviceAccountName: default
   featureFlagSource: ui-flag-source
   ingress:
@@ -119,7 +119,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: example-ingress
+  name: open-feature-demo-ingress
 spec:
   ingressClassName: nginx
   rules:

--- a/config/k8s/client-side-evaluation.yaml
+++ b/config/k8s/client-side-evaluation.yaml
@@ -56,13 +56,10 @@ spec:
     enabled: true
     annotations:
       nginx.ingress.kubernetes.io/force-ssl-redirect: 'false'
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
     hosts:
       - localhost
     ingressClassName: nginx
     pathType: Prefix
-    flagdPath: /(flagd\.evaluation.*)
-    ofrepPath: /(ofrep/.*)
 ---
 # Deployment of a demo-app using our custom resources
 apiVersion: apps/v1
@@ -94,8 +91,6 @@ spec:
           env:
             - name: FLAGD_PORT_WEB
               value: '80'
-            - name: FLAGD_PATH_PREFIX
-              value: 'flagd'
             - name: FLAGD_OFREP_PORT_WEB
               value: '80'
 ---
@@ -123,7 +118,6 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: localhost
       http:
         paths:
           - pathType: Prefix

--- a/config/k8s/client-side-evaluation.yaml
+++ b/config/k8s/client-side-evaluation.yaml
@@ -31,53 +31,38 @@ spec:
             - yellow
             - null
 ---
-# Flags for our backend application
-apiVersion: core.openfeature.dev/v1beta1
-kind: FeatureFlag
-metadata:
-  name: app-flags
-  labels:
-    app: open-feature-demo
-spec:
-  flagSpec:
-    flags:
-      fib-algo:
-        variants:
-          recursive: recursive
-          memo: memo
-          loop: loop
-          binet: binet
-        defaultVariant: recursive
-        state: ENABLED
-        targeting:
-          if:
-            - in:
-                - '@faas.com'
-                - var:
-                    - email
-            - binet
-            - null
-      use-remote-fib-service:
-        state: ENABLED
-        variants:
-          'on': true
-          'off': false
-        defaultVariant: 'off'
----
 # Feature flag source custom resource, configuring flagd to source flags from FeatureFlag CRDs
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlagSource
 metadata:
-  name: flag-sources
+  name: ui-flag-source
   labels:
     app: open-feature-demo
 spec:
   sources:
-    - source: app-flags
-      provider: kubernetes
     - source: ui-flags
       provider: kubernetes
-
+---
+# Standalone flagd for serving UI
+apiVersion: core.openfeature.dev/v1beta1
+kind: Flagd
+metadata:
+  name: flagd-ui
+spec:
+  replicas: 2
+  serviceAccountName: default
+  featureFlagSource: ui-flag-source
+  ingress:
+    enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/force-ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+    hosts:
+      - localhost
+    ingressClassName: nginx
+    pathType: Prefix
+    flagdPath: /(flagd\.evaluation.*)
+    ofrepPath: /(ofrep/.*)
 ---
 # Deployment of a demo-app using our custom resources
 apiVersion: apps/v1
@@ -97,18 +82,22 @@ spec:
         app: open-feature-demo
       annotations:
         openfeature.dev/enabled: 'true'
-        openfeature.dev/featureflagsource: 'flag-sources'
+        openfeature.dev/inprocessconfiguration: 'in-process-config'
     spec:
       containers:
         - name: open-feature-demo
           image: ghcr.io/open-feature/playground-app:v0.16.0 # x-release-please-version
-          args:
-            - flagd
           ports:
             - containerPort: 30000
+          args:
+            - flagd
           env:
             - name: FLAGD_PORT_WEB
-              value: '30002'
+              value: '80'
+            - name: FLAGD_PATH_PREFIX
+              value: 'flagd'
+            - name: FLAGD_OFREP_PORT_WEB
+              value: '80'
 ---
 # Service to expose our application
 apiVersion: v1
@@ -126,19 +115,21 @@ spec:
       targetPort: 30000
       nodePort: 30000
 ---
-# Service to expose flagd for client-side evaluations
-# Note that in production, it's recommended to run a dedicated flagd deployment to serve client-side evaluations.
-apiVersion: v1
-kind: Service
+# Ingress for our application
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: open-feature-demo-ui-service
-  labels:
-    app: open-feature-demo
+  name: example-ingress
 spec:
-  type: NodePort
-  selector:
-    app: open-feature-demo
-  ports:
-    - port: 30002
-      targetPort: 8013
-      nodePort: 30002
+  ingressClassName: nginx
+  rules:
+    - host: localhost
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: open-feature-demo-app-service
+                port:
+                  number: 30000

--- a/config/k8s/in-process-evaluation.yaml
+++ b/config/k8s/in-process-evaluation.yaml
@@ -1,36 +1,3 @@
-# Flags for our UI
-apiVersion: core.openfeature.dev/v1beta1
-kind: FeatureFlag
-metadata:
-  name: ui-flags
-  labels:
-    app: open-feature-demo
-spec:
-  flagSpec:
-    flags:
-      new-welcome-message:
-        state: ENABLED
-        variants:
-          'on': true
-          'off': false
-        defaultVariant: 'off'
-      hex-color:
-        variants:
-          red: c05543
-          green: 2f5230
-          blue: 0d507b
-          yellow: d4ac0d
-        defaultVariant: blue
-        state: ENABLED
-        targeting:
-          if:
-            - in:
-                - '@faas.com'
-                - var:
-                    - email
-            - yellow
-            - null
----
 # Flags for our backend application
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlag
@@ -49,14 +16,6 @@ spec:
           binet: binet
         defaultVariant: recursive
         state: ENABLED
-        targeting:
-          if:
-            - in:
-                - '@faas.com'
-                - var:
-                    - email
-            - binet
-            - null
       use-remote-fib-service:
         state: ENABLED
         variants:
@@ -68,16 +27,32 @@ spec:
 apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlagSource
 metadata:
-  name: flag-sources
+  name: app-flag-source
   labels:
     app: open-feature-demo
 spec:
   sources:
     - source: app-flags
       provider: kubernetes
-    - source: ui-flags
-      provider: kubernetes
-
+---
+# Standalone flagd for serving in-process provider
+apiVersion: core.openfeature.dev/v1beta1
+kind: Flagd
+metadata:
+  name: flagd-in-process
+spec:
+  replicas: 2
+  serviceType: ClusterIP
+  serviceAccountName: default
+  featureFlagSource: app-flag-source
+---
+# In-process provider configuration
+apiVersion: core.openfeature.dev/v1beta1
+kind: InProcessConfiguration
+metadata:
+  name: in-process-config
+spec:
+  host: flagd-in-process
 ---
 # Deployment of a demo-app using our custom resources
 apiVersion: apps/v1
@@ -97,18 +72,22 @@ spec:
         app: open-feature-demo
       annotations:
         openfeature.dev/enabled: 'true'
-        openfeature.dev/featureflagsource: 'flag-sources'
+        openfeature.dev/inprocessconfiguration: 'in-process-config'
     spec:
       containers:
         - name: open-feature-demo
           image: ghcr.io/open-feature/playground-app:v0.16.0 # x-release-please-version
-          args:
-            - flagd
           ports:
             - containerPort: 30000
+          args:
+            - flagd
           env:
             - name: FLAGD_PORT_WEB
-              value: '30002'
+              value: '80'
+            - name: FLAGD_PATH_PREFIX
+              value: 'flagd'
+            - name: FLAGD_OFREP_PORT_WEB
+              value: '80'
 ---
 # Service to expose our application
 apiVersion: v1
@@ -126,19 +105,21 @@ spec:
       targetPort: 30000
       nodePort: 30000
 ---
-# Service to expose flagd for client-side evaluations
-# Note that in production, it's recommended to run a dedicated flagd deployment to serve client-side evaluations.
-apiVersion: v1
-kind: Service
+# Ingress for our application
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: open-feature-demo-ui-service
-  labels:
-    app: open-feature-demo
+  name: example-ingress
 spec:
-  type: NodePort
-  selector:
-    app: open-feature-demo
-  ports:
-    - port: 30002
-      targetPort: 8013
-      nodePort: 30002
+  ingressClassName: nginx
+  rules:
+    - host: localhost
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: open-feature-demo-app-service
+                port:
+                  number: 30000

--- a/config/k8s/in-process-evaluation.yaml
+++ b/config/k8s/in-process-evaluation.yaml
@@ -41,7 +41,7 @@ kind: Flagd
 metadata:
   name: flagd-in-process
 spec:
-  replicas: 2
+  replicas: 1
   serviceType: ClusterIP
   serviceAccountName: default
   featureFlagSource: app-flag-source
@@ -109,7 +109,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: example-ingress
+  name: open-feature-demo-ingress
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Additional tutorial materials that depend on playground versioning.

The new manifests contain some duplication, but that's on purpose so they can be used together OR independently depending on the tutorial path users will take.